### PR TITLE
Improve provider version handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ This project is licensed under the terms of the [Apache License 2.0](LICENSE)
 
 This [terraform] module depends on providers from HashiCorp, Inc. which are licensed under MPL-2.0. You can obtain the respective source code for these provider here:
   * [`hashicorp/google`](https://github.com/hashicorp/terraform-provider-google)
-  * [`hashicorp/google-beta`](https://github.com/hashicorp/terraform-provider-google-beta)
 
 [terraform]: https://terraform.io/
 [FAQ]: ./docs/FAQ.md

--- a/versions.tf
+++ b/versions.tf
@@ -16,11 +16,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
-    }
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = "~> 4.0"
+      version = ">= 3.88.0"
     }
   }
   required_version = ">= 1.0"


### PR DESCRIPTION
- Remove google-beta provider, not used in the module
- change version constraint to ensure we are at least with latest 3.x provider having a breaking change.
- also allow google provider with version 4, as the module is compatible with it (removed the ~>3.0 constrain)
- not require provider version 4, as we don't depend on any feature from the v4 provider