### PR TITLE
CF-684 Remove support for module_variable_optional_attrs experiment

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -19,6 +19,5 @@ terraform {
       version = ">= 3.88.0"
     }
   }
-  required_version = ">= 1.0"
-  experiments      = [module_variable_optional_attrs]
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
With the release of Terraform 1.3, the experiment `module_variable_optional_attrs` has been ended. This makes Terraform versions newer than 1.2 fail without this change.

This change will be released in a new minor version of the module as Terraform will not use this new version due to the updated `required_version` version constraint.
