### PR TITLE
Add support for assiging storage.objectUser

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ module "tf-state-bucket" {
 | storage_admins | list of users with role roles/storage.admin on bucket level (authoritative) | `list(string)` | `[]` | no |
 | storage_class | Bucket's Storage Class | `string` | `"REGIONAL"` | no |
 | storage_object_admins | list of users with role roles/storage.objectAdmin on bucket level (authoritative) | `list(string)` | `[]` | no |
+| storage_object_users | list of users with role roles/storage.objectCreator on bucket level (authoritative) | `list(string)` | `[]` | no |
 | storage_object_creators | list of users with role roles/storage.objectCreator on bucket level (authoritative) | `list(string)` | `[]` | no |
 | storage_object_viewers | list of users with role roles/storage.objectViewer on bucket level (authoritative) | `list(string)` | `[]` | no |
 | uniform_access | Enables Uniform bucket-level access to a bucket | `bool` | `true` | no |

--- a/data.tf
+++ b/data.tf
@@ -1,4 +1,4 @@
-# Copyright 2021 METRO Digital GmbH
+# Copyright 2024 METRO Digital GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -73,6 +73,11 @@ data "google_iam_policy" "bucket" {
   binding {
     role    = "roles/storage.objectAdmin"
     members = compact(var.storage_object_admins)
+  }
+
+  binding {
+    role    = "roles/storage.objectUser"
+    members = compact(var.storage_object_users)
   }
 
   binding {

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2021 METRO Digital GmbH
+# Copyright 2024 METRO Digital GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -219,6 +219,12 @@ variable "storage_admins" {
 variable "storage_object_admins" {
   type        = list(string)
   description = "list of users with role roles/storage.objectAdmin on bucket level (authoritative)"
+  default     = []
+}
+
+variable "storage_object_users" {
+  type        = list(string)
+  description = "list of users with role roles/storage.objectUser on bucket level (authoritative)"
   default     = []
 }
 


### PR DESCRIPTION
The role storage.objectUser has more permissions than objectCreator (e.g. can delete/replace objects) but less than an objectAdmin. Thus, it's needed for implementing least privilege for simple upload and replace use cases.